### PR TITLE
Remove categoryId from name field in category picker

### DIFF
--- a/components/AutoCompleteSingle/AutoCompleteSingle.tsx
+++ b/components/AutoCompleteSingle/AutoCompleteSingle.tsx
@@ -13,7 +13,7 @@ const AutoCompleteSingle: React.FC<AmpSDKProps> = ({ ampSDK }) => {
       sx={{ width: '100%', marginTop: '6px' }}
       value={value}
       onChange={(event, val) => {
-        ampSDK.setValue(val)
+        ampSDK.setValue({...val, name: val.name.replace(/\(.*\)\s/, '')})
         setValue(val)
       }}
       onClose={() => {


### PR DESCRIPTION
Updated the onChange of the Autocomplete component in category picker to remove the category ID from the name property value when setting it in Amplience.

Previous JSON output: 
`{"name": "(mens) Mens"}`

New JSON ouptut:
`{"name": "Mens"}`

This change only alters the data that is applied with the Amplience SDK, the component still shows the ID in the select dropdown options so that the content editors can still use the autocomplete input to search for the category ID